### PR TITLE
Fix auto database repair to purge all partially flushed pushdata, inp…

### DIFF
--- a/conduit_index/conduit_index/load_balance_algo.py
+++ b/conduit_index/conduit_index/load_balance_algo.py
@@ -17,7 +17,8 @@ logger = logging.getLogger("distribute_load")
 def distribute_load(blk_hash, blk_height, count_added, block_size, tx_offsets_array) \
         -> List[WorkPart]:
     """tx_offsets_array must be all the tx_offsets in a full raw block
-    Todo - This very badly needs unittest coverage!
+    Todo - This very badly needs unittest coverage - and TDD for working around the risk of a
+        freakishly large transaction in the batch.
     """
     # logger.debug(f"Length of tx_offsets_array={len(tx_offsets_array)}")
 

--- a/conduit_lib/database/lmdb/lmdb_database.py
+++ b/conduit_lib/database/lmdb/lmdb_database.py
@@ -10,7 +10,7 @@ from io import BytesIO
 from math import ceil, log
 from pathlib import Path
 from struct import Struct
-from typing import List, Tuple, Dict, Optional, IO, Set
+from typing import List, Tuple, Optional, IO, Set
 
 import bitcoinx
 import cbor2
@@ -565,13 +565,13 @@ class LMDB_Database:
                     # LMDB only stores the mapping of hash -> location
                     tx_offsets_location = TxOffsetsArrayLocation(str(write_path), start_offset,
                         end_offset)
-                    self.logger.debug(f"writing tx offsets array ({hash_to_hex_str(block_hash)}): "
-                                      f"{tx_offsets_location}")
+                    # self.logger.debug(f"writing tx offsets array ({hash_to_hex_str(block_hash)}): "
+                    #                   f"{tx_offsets_location}")
                     cursor.put(block_hash, cbor2.dumps(tx_offsets_location))
 
                     start_offset += len(tx_offsets*SIZE_UINT64_T)
-                    self.logger.debug(f"block_hash={bitcoinx.hash_to_hex_str(block_hash)};"
-                                      f"tx_offsets={tx_offsets}")
+                    # self.logger.debug(f"block_hash={bitcoinx.hash_to_hex_str(block_hash)};"
+                    #                   f"tx_offsets={tx_offsets}")
         finally:
             file.close()
             acquired_flock.release()

--- a/conduit_lib/database/mysql/mysql_database.py
+++ b/conduit_lib/database/mysql/mysql_database.py
@@ -6,6 +6,7 @@ from functools import partial
 from typing import List, Tuple, Set
 
 import MySQLdb
+import bitcoinx
 from MySQLdb import _mysql
 
 from .mysql_api_queries import MySQLAPIQueries
@@ -102,8 +103,8 @@ class MySQLDatabase:
     def mysql_invalidate_mempool_rows(self):
         self.queries.mysql_invalidate_mempool_rows()
 
-    def mysql_update_api_tip_height_and_hash(self, api_tip_height: int, api_tip_hash: bytes):
-        self.queries.mysql_update_api_tip_height_and_hash(api_tip_height, api_tip_hash)
+    def mysql_update_checkpoint_tip(self, checkpoint_tip: bitcoinx.Header):
+        self.queries.mysql_update_checkpoint_tip(checkpoint_tip)
 
     # BULK LOADS
     def mysql_bulk_load_confirmed_tx_rows(self, tx_rows):

--- a/conduit_lib/ipc_sock_client.py
+++ b/conduit_lib/ipc_sock_client.py
@@ -127,8 +127,8 @@ class IPCSocketClient:
             self.wait_for_connection()
             return self.block_number_batched(block_hashes)  # recurse
 
-    def block_batched(self, block_requests: list[BlockSliceRequestType]) \
-            -> BatchedBlockSlices:
+    # Todo - make a streaming API for blocks to protect against freakishly large txs
+    def block_batched(self, block_requests: list[BlockSliceRequestType]) -> BatchedBlockSlices:
         """The packing protocol is a contiguous array of:
              block_number uint32,
              len_slice uin64,
@@ -136,7 +136,7 @@ class IPCSocketClient:
         try:
             # Request
             msg_req = ipc_sock_msg_types.BlockBatchedRequest(block_requests)
-            self.logger.debug(f"Sending {ipc_sock_commands.BLOCK_BATCHED} request: {msg_req}")
+            # self.logger.debug(f"Sending {ipc_sock_commands.BLOCK_BATCHED} request: {msg_req}")
             send_msg(self.sock, msg_req.to_cbor())
 
             # Recv


### PR DESCRIPTION
…ut, output and confirmed_transaction rows

- It also now avoids full table scans by using index-only lookups for all of these deletions
- It also now subsequently re-attempts to synchronize the previously failed batch before
proceeding to normal operations.
- Also changed the tx parsing ack queue to a zmq socket
- Refactored out index_blocks() method for reuse in handling db repair
- Renamed sync_state table to checkpoint_state and renamed anything referencing "api_tip" to "best_flushed_tip"
- General tidy ups