### PR TITLE
Fix p2p routing of big block chunks

### DIFF
--- a/tests_functional/test_bitcoin_p2p_client.py
+++ b/tests_functional/test_bitcoin_p2p_client.py
@@ -1,6 +1,4 @@
 import asyncio
-import queue
-
 import bitcoinx
 from bitcoinx import double_sha256, hash_to_hex_str, pack_varint, hex_str_to_hash
 import shutil
@@ -144,7 +142,8 @@ class MockHandlers(MessageHandlerProtocol):
     async def on_tx(self, rawtx: bytes, peer: BitcoinPeerInstance) -> None:
         self.got_message_queue.put_nowait((commands.TX, rawtx))
 
-    async def on_block_chunk(self, block_chunk_data: BlockChunkData, peer: BitcoinPeerInstance) -> None:
+    async def on_block_chunk(self, block_chunk_data: BlockChunkData, peer: BitcoinPeerInstance,
+            worker_id: int) -> None:
         self.got_message_queue.put_nowait((commands.BLOCK, block_chunk_data))
 
     async def on_block(self, block_data_msg: BlockDataMsg, peer: BitcoinPeerInstance) -> None:


### PR DESCRIPTION
- Depending on the task, it may or may not be okay to load balance chunks of a large block across different workers. In the case of building a merkle tree, it's easier to route all chunks to the same worker.
- For parsing transactions - this is an "embarrassingly parallel" task as long as you have the tx offsets to go with each chunk.