### PR TITLE
Place tighter constraints on memory allocations particularly for push…

### DIFF
--- a/conduit_index/conduit_index/workers/flush_blocks_thread.py
+++ b/conduit_index/conduit_index/workers/flush_blocks_thread.py
@@ -30,7 +30,7 @@ from ..workers.common import (
 if typing.TYPE_CHECKING:
     from .transaction_parser import TxParser
 
-BLOCKS_MAX_TX_BATCH_LIMIT = 100_000
+MAX_ROW_FLUSH_LIMIT = 100_000
 BLOCK_BATCHING_RATE = 0.3
 
 
@@ -104,7 +104,9 @@ class FlushConfirmedTransactionsThread(threading.Thread):
                     if len(tip_filter_notifications.pushdata_matches) > 0:
                         all_tip_filter_notifications.append(tip_filter_notifications)
 
-                    if len(txs) > BLOCKS_MAX_TX_BATCH_LIMIT:
+                    if len(txs) >= MAX_ROW_FLUSH_LIMIT or \
+                            len(pds) >= MAX_ROW_FLUSH_LIMIT or \
+                            len(ins) >= MAX_ROW_FLUSH_LIMIT:
                         (
                             db,
                             self.last_activity,

--- a/conduit_index/conduit_index/workers/flush_mempool_thread.py
+++ b/conduit_index/conduit_index/workers/flush_mempool_thread.py
@@ -29,7 +29,7 @@ from ..workers.common import (
 if typing.TYPE_CHECKING:
     from .transaction_parser import TxParser
 
-MEMPOOL_MAX_TX_BATCH_LIMIT = 2000
+MAX_ROW_FLUSH_LIMIT = 100000
 MEMPOOL_BATCHING_RATE = 0.1
 
 
@@ -82,7 +82,9 @@ class FlushMempoolTransactionsThread(threading.Thread):
                     utxo_spends += new_utxo_spends
                     pushdata_matches_tip_filter += new_pushdata_matches
 
-                    if len(txs_mempool) > MEMPOOL_MAX_TX_BATCH_LIMIT - 1:
+                    if len(txs_mempool) >= MAX_ROW_FLUSH_LIMIT or \
+                            len(pds) >= MAX_ROW_FLUSH_LIMIT or \
+                            len(ins) >= MAX_ROW_FLUSH_LIMIT:
                         self.logger.debug(f"hit max mempool batch size ({len(txs_mempool)})")
                         (
                             db,

--- a/conduit_index/conduit_index/workers/mempool_parsing_thread.py
+++ b/conduit_index/conduit_index/workers/mempool_parsing_thread.py
@@ -48,11 +48,11 @@ class MempoolParsingThread(threading.Thread):
         self.worker_id = worker_id
         self.mempool_tx_flush_queue: queue.Queue[
             tuple[
-                MySQLFlushBatch,MempoolTxAck,
+                MySQLFlushBatch, MempoolTxAck,
                 list[InputRowParsed],
                 list[PushdataRowParsed]
             ]
-        ] = queue.Queue(maxsize=100_000)
+        ] = queue.Queue(maxsize=100)
 
         self.zmq_context = zmq.Context[zmq.Socket[bytes]]()
         self.socket_mempool_tx = connect_non_async_zmq_socket(

--- a/conduit_lib/database/scylladb/db.py
+++ b/conduit_lib/database/scylladb/db.py
@@ -97,9 +97,9 @@ class ScyllaDB(DBInterface):
     def ping(self) -> None:
         # The below query is lightweight and often used to test connectivity
         rs = self.session.execute('SELECT now() FROM system.local')
-        print("Ping successful, connected to cluster: " + str(self.cluster.metadata.cluster_name))
+        self.logger.debug(f"Ping successful, connected to cluster: {self.cluster.metadata.cluster_name}")
         for row in rs:
-            print("Date and time from ScyllaDB:", row[0])
+            self.logger.debug(f"Date and time from ScyllaDB: {row[0]}")
 
     def start_transaction(self) -> None:
         pass  # Not used in the ScyllaDB implementation


### PR DESCRIPTION
…data rows which can spike up dramatically into the tens of millions per worker process

- Even this wouldn't be an issue if these tens of millions were not being pooled up in the flush thread which takes it up to possibly hundreds of millions.
- E.g. if a queue.Queue can be filled at a rate of 250_000 per second (per worker), it only takes 100_000 transactions (1/3 of a second), each with 1000 p2pkh outputs per transaction to start getting scary. That would put the total memory allocation up over 40GB on its own! When MariaDB is dropped and so hex conversion can be dropped, this will be cut down to 1/3 of this value at around 13GB. But even then, it's all wasted memory allocation and doesn't help performance in any way.
- A good target for peak memory allocation should be closer to 4-5GB